### PR TITLE
Make minor changes to Cargo.toml and docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
 resolver = "2"
 members = ["embedded-fans", "embedded-fans-async"]
+
+[patch.crates-io]
+embedded-fans = { path = "embedded-fans" }

--- a/embedded-fans-async/Cargo.toml
+++ b/embedded-fans-async/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Microsoft"]
+authors = ["Kurtis Dinelle <t-kudinelle@microsoft.com>"]
 categories = ["embedded", "no-std", "hardware-support"]
 edition = "2021"
 rust-version = "1.79"
@@ -11,8 +11,8 @@ repository = "https://github.com/pop-project/embedded-fans"
 version = "0.1.0"
 
 [features]
-defmt = ["dep:defmt"]
+defmt = ["dep:defmt", "embedded-fans/defmt"]
 
 [dependencies]
-embedded-fans = { version = "0.1.0", path = "../embedded-fans" }
+embedded-fans = "0.1.0"
 defmt = { package = "defmt", version = "0.3.7", optional = true }

--- a/embedded-fans-async/src/lib.rs
+++ b/embedded-fans-async/src/lib.rs
@@ -20,7 +20,7 @@
 //! }
 //!
 //! impl embedded_fans_async::Error for Error {
-//!     fn kind(&self) -> ErrorKind {
+//!     fn kind(&self) -> embedded_fans::ErrorKind {
 //!         match *self {
 //!             // ...
 //!         }
@@ -59,7 +59,8 @@
 //! ```
 
 #![doc = include_str!("../README.md")]
-#![warn(missing_docs)]
+#![forbid(missing_docs)]
+#![forbid(unsafe_code)]
 #![no_std]
 #![allow(async_fn_in_trait)]
 

--- a/embedded-fans/Cargo.toml
+++ b/embedded-fans/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Microsoft"]
+authors = ["Kurtis Dinelle <t-kudinelle@microsoft.com>"]
 categories = ["embedded", "no-std", "hardware-support"]
 edition = "2021"
 rust-version = "1.79"

--- a/embedded-fans/src/lib.rs
+++ b/embedded-fans/src/lib.rs
@@ -20,7 +20,7 @@
 //! }
 //!
 //! impl embedded_fans::Error for Error {
-//!     fn kind(&self) -> ErrorKind {
+//!     fn kind(&self) -> embedded_fans::ErrorKind {
 //!         match *self {
 //!             // ...
 //!         }
@@ -59,7 +59,8 @@
 //! ```
 
 #![doc = include_str!("../README.md")]
-#![warn(missing_docs)]
+#![forbid(missing_docs)]
+#![forbid(unsafe_code)]
 #![no_std]
 
 /// Fan error.


### PR DESCRIPTION
This PR implements the same suggestions made for the `embedded-sensors` crate, primarily concerning a few details in Cargo.toml.