### PR TITLE
Fix potential overflow in percent calculation

### DIFF
--- a/embedded-fans/src/lib.rs
+++ b/embedded-fans/src/lib.rs
@@ -156,7 +156,9 @@ pub trait Fan: ErrorType {
     #[inline]
     fn set_speed_percent(&mut self, percent: u8) -> Result<u16, Self::Error> {
         debug_assert!((0..=100).contains(&percent));
-        self.set_speed_rpm((self.max_rpm() * u16::from(percent)) / 100)
+
+        // Cast operands to u32 to prevent overflow during multiplication
+        self.set_speed_rpm(((u32::from(self.max_rpm()) * u32::from(percent)) / 100) as u16)
     }
 
     /// Sets the fan's speed to the maximum RPM it's capable of running at.


### PR DESCRIPTION
This fixes a potential runtime panic when the given percent or rpm is high enough. Cast both to u32 to perform calculation before converting back to u16.