### PR TITLE
Fix potential overflow in async percent calculation

### DIFF
--- a/embedded-fans-async/src/lib.rs
+++ b/embedded-fans-async/src/lib.rs
@@ -87,7 +87,9 @@ pub trait Fan: ErrorType {
     #[inline]
     async fn set_speed_percent(&mut self, percent: u8) -> Result<u16, Self::Error> {
         debug_assert!((0..=100).contains(&percent));
-        self.set_speed_rpm((self.max_rpm() * u16::from(percent)) / 100)
+
+        // Cast operands to u32 to prevent overflow during multiplication
+        self.set_speed_rpm(((u32::from(self.max_rpm()) * u32::from(percent)) / 100) as u16)
             .await
     }
 


### PR DESCRIPTION
I apologize, I forgot to apply the previous overflow fix to the async implementation as well. This PR fixes that.