### PR TITLE
Add start method

### DIFF
--- a/embedded-fans-async/Cargo.toml
+++ b/embedded-fans-async/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "embedded-fans-async"
 readme = "README.md"
 repository = "https://github.com/OpenDevicePartnership/embedded-fans"
-version = "0.1.0"
+version = "0.2.0"
 
 [features]
 defmt = ["dep:defmt", "embedded-fans/defmt"]

--- a/embedded-fans-async/src/lib.rs
+++ b/embedded-fans-async/src/lib.rs
@@ -100,6 +100,13 @@ pub trait Fan: ErrorType {
         Ok(())
     }
 
+    /// Starts the fan at its minimum RPM needed to begin from a dead stop.
+    #[inline]
+    async fn start(&mut self) -> Result<(), Self::Error> {
+        self.set_speed_rpm(self.min_start_rpm()).await?;
+        Ok(())
+    }
+
     /// Stops the fan completely.
     #[inline]
     async fn stop(&mut self) -> Result<(), Self::Error> {

--- a/embedded-fans/Cargo.toml
+++ b/embedded-fans/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "embedded-fans"
 readme = "README.md"
 repository = "https://github.com/OpenDevicePartnership/embedded-fans"
-version = "0.1.0"
+version = "0.2.0"
 
 [features]
 defmt = ["dep:defmt"]

--- a/embedded-fans/src/lib.rs
+++ b/embedded-fans/src/lib.rs
@@ -168,6 +168,13 @@ pub trait Fan: ErrorType {
         Ok(())
     }
 
+    /// Starts the fan at its minimum RPM needed to begin from a dead stop.
+    #[inline]
+    fn start(&mut self) -> Result<(), Self::Error> {
+        self.set_speed_rpm(self.min_start_rpm())?;
+        Ok(())
+    }
+
     /// Stops the fan completely.
     #[inline]
     fn stop(&mut self) -> Result<(), Self::Error> {


### PR DESCRIPTION
This PR adds a `start()` method to traits. The reasoning behind this is `start()` may be semantically different from `set_speed_rpm(min_start_rpm)`.

For example, user may have disabled PWM timer in `stop()` to save power and then would re-enable PWM timer in `start()` before setting the fan's RPM.

Bumps version to `v0.2.0` as well.