### PR TITLE
Add requested_rpm trait method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,14 +51,14 @@ dependencies = [
 
 [[package]]
 name = "embedded-fans"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "defmt",
 ]
 
 [[package]]
 name = "embedded-fans-async"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "defmt",
  "embedded-fans 0.1.0",

--- a/embedded-fans-async/Cargo.toml
+++ b/embedded-fans-async/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "embedded-fans-async"
 readme = "README.md"
 repository = "https://github.com/OpenDevicePartnership/embedded-fans"
-version = "0.2.0"
+version = "0.3.0"
 
 [features]
 defmt = ["dep:defmt", "embedded-fans/defmt"]

--- a/embedded-fans-async/src/lib.rs
+++ b/embedded-fans-async/src/lib.rs
@@ -46,6 +46,7 @@
 //!
 //!     async fn set_speed_rpm(&mut self, rpm: u16) -> Result<u16, Self::Error> {
 //!         // ...
+//!         // Store requested rpm...
 //!         Ok(rpm)
 //!     }
 //! }
@@ -54,6 +55,11 @@
 //!     async fn rpm(&mut self) -> Result<u16, Self::Error> {
 //!         // ...
 //!         Ok(42)
+//!     }
+//!
+//!     fn requested_rpm(&self) -> u16 {
+//!         // Retrieve last requested rpm...
+//!         42
 //!     }
 //! }
 //! ```
@@ -156,11 +162,19 @@ impl<T: Fan + ?Sized> Fan for &mut T {
 pub trait RpmSense: ErrorType {
     /// Returns the fan's currently measured RPM.
     async fn rpm(&mut self) -> Result<u16, Self::Error>;
+
+    /// Returns the fan's last requested set RPM.
+    fn requested_rpm(&self) -> u16;
 }
 
 impl<T: RpmSense + ?Sized> RpmSense for &mut T {
     #[inline]
     async fn rpm(&mut self) -> Result<u16, Self::Error> {
         T::rpm(self).await
+    }
+
+    #[inline]
+    fn requested_rpm(&self) -> u16 {
+        T::requested_rpm(self)
     }
 }

--- a/embedded-fans/Cargo.toml
+++ b/embedded-fans/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "embedded-fans"
 readme = "README.md"
 repository = "https://github.com/OpenDevicePartnership/embedded-fans"
-version = "0.2.0"
+version = "0.3.0"
 
 [features]
 defmt = ["dep:defmt"]

--- a/embedded-fans/src/lib.rs
+++ b/embedded-fans/src/lib.rs
@@ -46,6 +46,7 @@
 //!
 //!     fn set_speed_rpm(&mut self, rpm: u16) -> Result<u16, Self::Error> {
 //!         // ...
+//!         // Store requested rpm...
 //!         Ok(rpm)
 //!     }
 //! }
@@ -54,6 +55,11 @@
 //!     fn rpm(&mut self) -> Result<u16, Self::Error> {
 //!         // ...
 //!         Ok(42)
+//!     }
+//!
+//!     fn requested_rpm(&self) -> u16 {
+//!         // Retrieve last requested rpm...
+//!         42
 //!     }
 //! }
 //! ```
@@ -224,11 +230,19 @@ impl<T: Fan + ?Sized> Fan for &mut T {
 pub trait RpmSense: ErrorType {
     /// Returns the fan's currently measured RPM.
     fn rpm(&mut self) -> Result<u16, Self::Error>;
+
+    /// Returns the fan's last requested set RPM.
+    fn requested_rpm(&self) -> u16;
 }
 
 impl<T: RpmSense + ?Sized> RpmSense for &mut T {
     #[inline]
     fn rpm(&mut self) -> Result<u16, Self::Error> {
         T::rpm(self)
+    }
+
+    #[inline]
+    fn requested_rpm(&self) -> u16 {
+        T::requested_rpm(self)
     }
 }


### PR DESCRIPTION
This PR adds a `requested_rpm` method which should return the last requested rpm set by the various `set_speed_*` methods.

The use case for this is to detect differences in actual measured RPM vs what the caller intended to set the RPM to. The `thermal-service` can use this, for example, to detect a stalled or runaway fan.

Version bumped to `0.3.0` as this is a breaking change since `requested_rpm` does not have a default implementation. Will announce on Discord after merge.